### PR TITLE
fpm.toml: fix parsing

### DIFF
--- a/fpm.toml
+++ b/fpm.toml
@@ -17,37 +17,37 @@ simulated-annealing = { git="https://github.com/jacobwilliams/simulated-annealin
 [library]
 source-dir="src/"
 
-[[ test ]]
+[[test]]
 name="root-finding-single-test"
 source-dir="test/"
 main="root_finding_single_test.f90"
 
-[[ test ]]
+[[test]]
 name="root-finding-mult-test"
 source-dir="test/"
 main="root_finding_mult_test.f90"
 
-[[ test ]]
+[[test]]
 name="static-opt-test"
 source-dir="test/"
 main="static_opt_test.f90"
 
-[[ test ]]
+[[test]]
 name="tauchen-test"
 source-dir="test/"
 main="tauchen_test.f90"
 
-[[ test ]]
+[[test]]
 name="markov-test"
 source-dir="test/"
 main="markov_test.f90"
 
-[[ test ]]
+[[test]]
 name="io-test"
 source-dir="test/"
 main="io_test.f90"
 
-[[ test ]]
+[[test]]
 name="global-opt-test"
 source-dir="test/"
 main="global_opt_test.f90"


### PR DESCRIPTION
While this [will be fixed in the next release](https://github.com/fortran-lang/fpm/issues/971) of `fpm`, it is broken at the moment.

See also: https://github.com/jacobwilliams/quadpack/issues/26